### PR TITLE
Start okr project containers

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -1,0 +1,1 @@
+# OKR Apps package

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -33,7 +33,7 @@ EXPOSE 5001
 # Set environment variables
 ENV FLASK_ENV=production
 ENV FLASK_APP=apps/api/app.py
-ENV PYTHONPATH=/app/src:/app
+ENV PYTHONPATH=/app:/app/src
 ENV PYTHONUNBUFFERED=1
 
 # Health check
@@ -41,5 +41,6 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD curl -f http://localhost:5001/health || exit 1
 
 # Use gunicorn for production with proper configuration
+WORKDIR /app
 CMD ["gunicorn", "--bind", "0.0.0.0:5001", "--workers", "2", "--worker-class", "sync", "--timeout", "120", "--keep-alive", "5", "--max-requests", "1000", "--max-requests-jitter", "100", "apps.api.app:app"]
 

--- a/apps/api/__init__.py
+++ b/apps/api/__init__.py
@@ -1,0 +1,1 @@
+# OKR API package


### PR DESCRIPTION
Fix `ModuleNotFoundError` in the `okr_api` container by adding Python package `__init__.py` files and adjusting the Dockerfile's `PYTHONPATH` and `WORKDIR`.

The `okr_api` container failed to start because gunicorn could not import `apps.api.app:app`. This was due to the `apps` and `apps/api` directories not being recognized as Python packages (missing `__init__.py` files) and the Docker container's `PYTHONPATH` not being correctly configured for the application's structure. These changes ensure the Python module system can properly locate and load the Flask application.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f587ee3-605e-49aa-aa48-a9e733e57987">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1f587ee3-605e-49aa-aa48-a9e733e57987">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

