### PR TITLE
Changes from background agent bc-aba02a8b-3f36-4a5e-b2ac-de70be7af509

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -32,5 +32,5 @@ ENV PYTHONUNBUFFERED=1
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD curl -f http://localhost:5001/health || exit 1
 
-CMD ["gunicorn", "--bind", "0.0.0.0:5001", "--workers", "2", "--worker-class", "sync", "--timeout", "120", "--keep-alive", "5", "--max-requests", "1000", "--max-requests-jitter", "100", "apps.api.app:app"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5001", "--workers", "2", "--worker-class", "sync", "--timeout", "120", "--keep-alive", "5", "--max-requests", "1000", "--max-requests-jitter", "100", "api.app:app"]
 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+# Make top-level `api` a package to allow `api.app` import

--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,2 @@
+from apps.api.app import app  # re-export Flask app for gunicorn module path compatibility
+


### PR DESCRIPTION
Fix Gunicorn `ModuleNotFoundError` by adjusting the app import path and creating a compatibility shim.

The `okr_api` container failed to boot due to Gunicorn being unable to locate the Flask application. This PR resolves the `ModuleNotFoundError: No module named 'api.app'` by:
- Changing the Gunicorn app import path in `api/Dockerfile` from `apps.api.app:app` to `api.app:app`.
- Creating `api/__init__.py` to establish `api` as a Python package.
- Adding `api/app.py` as a shim to re-export the Flask app from `apps.api.app`, ensuring the new import path resolves correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-aba02a8b-3f36-4a5e-b2ac-de70be7af509">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aba02a8b-3f36-4a5e-b2ac-de70be7af509">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

