### PR TITLE
Fix missing api.app module

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,6 +166,7 @@ services:
       context: .
       dockerfile: apps/api/Dockerfile
     container_name: okr_api
+    working_dir: /app
     ports:
       - "5001:5001"
     volumes:
@@ -180,10 +181,12 @@ services:
     networks:
       - okr_net
     environment:
+      - PYTHONPATH=/app:/app/src
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
       - AIRFLOW_BASE_URL=http://airflow-webserver:8080
       - AIRFLOW_USER=admin
       - AIRFLOW_PASSWORD=admin
+    command: ["gunicorn", "--bind", "0.0.0.0:5001", "--workers", "2", "--worker-class", "sync", "--timeout", "120", "--keep-alive", "5", "--max-requests", "1000", "--max-requests-jitter", "100", "apps.api.app:app"]
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:5001/health || exit 1"]
       interval: 30s


### PR DESCRIPTION
Fix `ModuleNotFoundError` in `okr_api` by explicitly setting Gunicorn app path, working directory, and `PYTHONPATH` in `docker-compose.yml`.

The `okr_api` container repeatedly failed to boot due to Gunicorn being unable to locate the `api.app` module. This was resolved by explicitly configuring the `working_dir` to `/app`, adding `/app` and `/app/src` to the `PYTHONPATH`, and specifying the full module path `apps.api.app:app` in the Gunicorn command.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb661410-84d8-40f3-a983-93a6f458d8ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cb661410-84d8-40f3-a983-93a6f458d8ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

