### PR TITLE
Start okr project containers

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,7 @@
+"""Compatibility wrapper package.
+
+Allows importing `api.app` by re-exporting from `apps.api.app`.
+"""
+
+from apps.api.app import app  # noqa: F401
+

--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,9 @@
+"""Compatibility module to support legacy import path `api.app`.
+
+This module simply re-exports the Flask application instance from
+`apps.api.app` so that both `apps.api.app:app` and `api.app:app` work
+with Gunicorn or other WSGI servers.
+"""
+
+from apps.api.app import app  # noqa: F401
+

--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -1,0 +1,2 @@
+"""Top-level package marker for application modules."""
+

--- a/apps/api/__init__.py
+++ b/apps/api/__init__.py
@@ -1,0 +1,7 @@
+"""API service package marker.
+
+Exposes the Flask application instance as `app` for WSGI servers.
+"""
+
+from .app import app  # noqa: F401
+


### PR DESCRIPTION
Add Python package init files and compatibility modules to resolve `ModuleNotFoundError` for the API service.

The `okr_api` service failed to start with "No module named 'api.app'" because Gunicorn was attempting to import `api.app` while the actual application was located at `apps.api.app`. This PR adds `__init__.py` files to correctly define Python packages and introduces wrapper modules (`api/__init__.py`, `api/app.py`) that re-export the application from `apps.api.app`, ensuring both import paths are valid.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f9e6781-75ec-4ea4-822f-b1bb2da7efe3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9f9e6781-75ec-4ea4-822f-b1bb2da7efe3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

