### PR TITLE
Fix all package import errors in Airflow DAGs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,7 +162,7 @@ services:
     restart: always
     networks:
       - okr_net
-    command: ["airflow", "webserver"]
+    command: ["bash", "-lc", "pip install --no-cache-dir -r /opt/airflow/src/requirements-airflow.txt && airflow webserver"]
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"]
       interval: 30s
@@ -204,7 +204,7 @@ services:
     restart: always
     networks:
       - okr_net
-    command: ["airflow", "scheduler"]
+    command: ["bash", "-lc", "pip install --no-cache-dir -r /opt/airflow/src/requirements-airflow.txt && airflow scheduler"]
     healthcheck:
       test: ["CMD-SHELL", "airflow jobs check --hostname $(hostname) || exit 1"]
       interval: 30s
@@ -295,24 +295,18 @@ services:
 
   # MLflow tracking server
   mlflow:
-    image: python:3.11-slim
+    image: ghcr.io/mlflow/mlflow:v2.14.1
     container_name: okr_mlflow
     ports:
       - "5000:5000"
     volumes:
-      - ./:/app
       - mlflow_data:/mlflow
-    working_dir: /app
     depends_on:
       airflow-db:
         condition: service_healthy
     environment:
-      - MLFLOW_TRACKING_URI=http://localhost:5000
-      - MLFLOW_TRACKING_USERNAME=mlflow
-      - MLFLOW_TRACKING_PASSWORD=mlflow
-    command: >
-      bash -c "pip install mlflow psycopg2-binary &&
-               mlflow server --host 0.0.0.0 --port 5000 --backend-store-uri postgresql://airflow:airflow@airflow-db:5432/airflow --default-artifact-root /mlflow"
+      - MLFLOW_ARTIFACT_ROOT=/mlflow
+    command: ["mlflow", "server", "--host", "0.0.0.0", "--port", "5000", "--backend-store-uri", "postgresql://airflow:airflow@airflow-db:5432/airflow", "--default-artifact-root", "/mlflow"]
     restart: always
     networks:
       - okr_net


### PR DESCRIPTION
Install missing Python dependencies in Airflow containers and switch MLflow to the official image to resolve DAG import errors and MLflow container crashes.

Airflow DAGs were failing due to `ModuleNotFoundError` for `scikit-learn`, `kafka-python`, and `joblib`. These packages are now installed at container startup. The `okr_mlflow` container was continuously restarting, so it has been switched to the official MLflow Docker image with proper configuration for its backend and artifact store.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff8c7479-61ae-405e-a1a8-be1a4ee270fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ff8c7479-61ae-405e-a1a8-be1a4ee270fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

