### PR TITLE
Fix all package import errors in Airflow DAGs

### DIFF
--- a/deploy/mlflow/Dockerfile
+++ b/deploy/mlflow/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+# Install system dependencies needed by MLflow and psycopg2
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential gcc && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install MLflow with Postgres support
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir mlflow psycopg2-binary
+
+# Create artifact root directory
+RUN mkdir -p /mlflow
+
+EXPOSE 5000
+
+CMD mlflow server --host 0.0.0.0 --port 5000 --backend-store-uri postgresql://airflow:airflow@airflow-db:5432/airflow --default-artifact-root /mlflow

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,10 @@ services:
 
   # Airflow webserver
   airflow-webserver:
-    image: apache/airflow:2.9.2
+    build:
+      context: ./deploy/airflow
+      dockerfile: Dockerfile
+    image: okr_airflow_custom:latest
     container_name: okr_airflow_webserver
     depends_on:
       airflow-db:
@@ -172,7 +175,7 @@ services:
 
   # Airflow scheduler
   airflow-scheduler:
-    image: apache/airflow:2.9.2
+    image: okr_airflow_custom:latest
     container_name: okr_airflow_scheduler
     depends_on:
       airflow-db:
@@ -295,7 +298,10 @@ services:
 
   # MLflow tracking server
   mlflow:
-    image: python:3.11-slim
+    build:
+      context: ./deploy/mlflow
+      dockerfile: Dockerfile
+    image: okr_mlflow_custom:latest
     container_name: okr_mlflow
     ports:
       - "5000:5000"


### PR DESCRIPTION
Add custom Docker images for Airflow and MLflow to resolve missing module errors and ensure full functionality.

The original Airflow and MLflow containers lacked necessary Python packages (`sklearn`, `kafka-python`, `joblib`, `mlflow`, `psycopg2-binary`) causing DAG import failures and preventing MLflow from connecting to its backend. Custom Dockerfiles were created to include these dependencies, and `docker-compose.yml` was updated to use these new images.

---
<a href="https://cursor.com/background-agent?bcId=bc-afeec473-6c90-44c9-a784-3c64ffc4a893">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-afeec473-6c90-44c9-a784-3c64ffc4a893">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

