### PR TITLE
Check okr api container health

### DIFF
--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -6,3 +6,4 @@ joblib>=1.2.0
 pandas>=1.5.0
 numpy>=1.21.0
 scikit-learn>=1.1.0
+mlflow==2.8.1


### PR DESCRIPTION
Add `mlflow` to `apps/api/requirements.txt` to resolve `okr_api` container startup failure.

The `okr_api` container was failing its healthcheck because `mlflow` was imported by `apps/api/app.py` at startup via `src/mlflow_server.py` but was not declared as a dependency, causing the service to crash.

---
<a href="https://cursor.com/background-agent?bcId=bc-76f01795-5cab-46d7-98ba-6b5f7be26eb9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-76f01795-5cab-46d7-98ba-6b5f7be26eb9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

